### PR TITLE
Make `license` seperate block to properly cite it

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,4 +32,6 @@ Alipay account email: i@0x142857.com
 
 Bitcoin address: [12ExMbLmtYsyyj4GTcGQrB64M4DsiAN3eN](http://blockexplorer.com/address/12ExMbLmtYsyyj4GTcGQrB64M4DsiAN3eN)
 
+###License
+
 Licensed under MIT license.


### PR DESCRIPTION
Citing `https://github.com/0x142857/Miu#donate` as license url doesn't seem quite well.
